### PR TITLE
Updates, bug fixes, tests, docs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,4 @@
-Risto Stevcev  
-Dario Oddenino
+* Risto Stevcev
+* Dario Oddenino
+* Liam Goodacre (https://github.com/LiamGoodacre)
+

--- a/src/Data/TemplateString/TemplateString.js
+++ b/src/Data/TemplateString/TemplateString.js
@@ -1,8 +1,9 @@
 
-// module Data.TemplateString
+exports._buildExclamationKeyObject = function (tuples) {
+  var valueMap = {};
+  tuples.forEach(function (tuple) {
+    valueMap['!' + tuple.value0] = tuple.value1;
+  });
+  return valueMap;
+};
 
-exports._template = function(str, tuples) {
-  return tuples.reduce(function(newStr, tuple) {
-    return newStr.replace(new RegExp('\\${'+ tuple.value0 +'}', 'g'), tuple.value1);
-  }, str);
-}

--- a/src/Data/TemplateString/TemplateString.purs
+++ b/src/Data/TemplateString/TemplateString.purs
@@ -5,21 +5,34 @@ module Data.TemplateString
   , templateS  
   ) where
 
-import Prelude (map, ($), (<<<), show)
-import Data.Function.Uncurried (Fn2, runFn2)
+import Prelude (map, ($), (<<<), show, (<>))
 import Data.Tuple (Tuple)
 import Data.Show (class Show)
+import Data.TemplateString.Unsafe (templateBy)
 
 -- | This is the safe version. The user is required to give a String representation of the object
+-- |
+-- | Example:
+-- | ```purescript
+-- | > "${foo} ${bar}" <^> ["foo" /\ "the ${bar} was", "bar" /\ "bananas"]
+-- | = "the ${bar} was bananas"
+-- | ```
 template :: String -> Array (Tuple String String) -> String
-template = runFn2 _template
+template tmpl = templateBy ("!" <> _) tmpl <<< _buildExclamationKeyObject
 
 infix 7 template as <^>
 
 -- | This version can use any instance of Show
+-- |
+-- | Example:
+-- | ```purescript
+-- | > "${one} and ${two}" <-> ["one" /\ 1, "two" /\ 2]
+-- | = "1 and 2"
+-- | ```
 templateS :: forall a. (Show a) => String -> Array (Tuple String a) -> String
-templateS s vs = runFn2 _template s $ (map <<< map) show vs
+templateS tmpl = template tmpl <<< map (map show)
 
 infix 7 templateS as <->
 
-foreign import _template :: Fn2 String (Array (Tuple String String)) String
+foreign import _buildExclamationKeyObject :: forall e. Array (Tuple String String) -> { | e }
+

--- a/src/Data/TemplateString/Unsafe/TemplateString.js
+++ b/src/Data/TemplateString/Unsafe/TemplateString.js
@@ -1,8 +1,10 @@
 
-// module Data.TemplateString.Unsafe
+var templatePattern = /\$\{([^}]+)\}/g;
 
-exports._template = function(str, obj) {
-  return Object.keys(obj).reduce(function(newStr, key) {
-    return newStr.replace(new RegExp('\\${'+ key +'}', 'g'), obj[key]);
-  }, str);
-}
+exports._templateBy = function (keyFrom, str, obj) {
+  return str.replace(templatePattern, function (match, ident) {
+     var key = keyFrom(ident);
+     return Object.hasOwnProperty.call(obj, key) ? obj[key] : match;
+  });
+};
+

--- a/src/Data/TemplateString/Unsafe/TemplateString.purs
+++ b/src/Data/TemplateString/Unsafe/TemplateString.purs
@@ -1,14 +1,34 @@
 module Data.TemplateString.Unsafe
   ((<~>)
   , template
+  , templateBy
   ) where
 
-import Data.Function.Uncurried (Fn2, runFn2)
+import Control.Category (id)
+import Data.Function.Uncurried (Fn3, runFn3)
 
--- | This is the unsafe version. Javascript will coerce whatever it's given to a string
+-- | Unsafe: JavaScript will coerce values to strings.
+-- | Supports a key mapping function for transforming keys found in the template.
+-- |
+-- | Example:
+-- | ```purescript
+-- | > templateBy String.toUpper "${foo} ${Foo} ${FOO}" { FOO: 42 }
+-- | = "42 42 42"
+-- | ```
+templateBy :: forall a. (String -> String) -> String -> { | a } -> String
+templateBy = runFn3 _templateBy
+
+-- | Unsafe: JavaScript will coerce values to strings.
+-- | Keys must match exactly.
+-- |
+-- | Example:
+-- | ```purescript
+-- | > "${foo} ${Foo} ${FOO} ${Bar}" <~> { Foo: 42, Bar: "!!!" }
+-- | = "${foo} 42 ${FOO} !!!"
+-- | ```
 template :: forall a. String -> { | a } -> String
-template = runFn2 _template
+template = runFn3 _templateBy id
 
 infix 7 template as <~>
 
-foreign import _template :: forall a. Fn2 String { | a } String
+foreign import _templateBy :: forall a. Fn3 (String -> String) String { | a } String

--- a/test/Data/TemplateString.purs
+++ b/test/Data/TemplateString.purs
@@ -1,4 +1,4 @@
-module Test.TemplateString where
+module Test.Data.TemplateString where
 
 import Prelude (Unit, bind, (==))
 import Control.Monad.Eff (Eff)
@@ -6,10 +6,10 @@ import Control.Monad.Eff.Console (CONSOLE)
 
 import Test.Unit (test, suite)
 import Test.Unit.Main (runTest)
-import Test.Unit.Assert (assert)
+import Test.Unit.Assert (assert, equal)
 import Test.Unit.Console (TESTOUTPUT)
 import Data.TemplateString.Unsafe ((<~>))
-import Data.TemplateString ((<^>)) 
+import Data.TemplateString ((<^>))
 
 import Data.Tuple.Nested
 
@@ -25,3 +25,16 @@ main = runTest do
     test "template" do
       assert "single" ("Hello, ${name}!" <^> ["name" /\ "Mr. Foo"] == "Hello, Mr. Foo!")
       assert "multi" ("Hello, ${fName} ${lName}!" <^> ["fName" /\ "Foo", "lName" /\ "Bar"] == "Hello, Foo Bar!")
+
+  suite "Injection safe" do
+    test "no past-dependent substitutions" do
+      -- the value being templated in shouldn't affect other substitutions
+      let built = "${one} => ${two}" <^> ["one" /\ "${two}", "two" /\ "bar"]
+      let expected = "${two} => bar"
+      -- specifically that the above isn't `"bar => bar"`
+      equal expected built
+
+  suite "Malicious keys" do
+    test "do no harm" do
+      equal "42" ("${__proto__}" <^> ["__proto__" /\ "42"])
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,14 @@
+module Test.Main where
+
+import Prelude (Unit)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE)
+
+import Test.Unit.Console (TESTOUTPUT)
+
+import Test.Data.TemplateString as TemplateString
+
+
+main :: Eff ( console :: CONSOLE, testOutput :: TESTOUTPUT ) Unit
+main = TemplateString.main
+


### PR DESCRIPTION
- `pulp test` failed to run due to no `Test.Main`
  - renamed `Test.TemplateString` to `Test.Main`
- added test case for injection bug
- reimplemented substitution to account for injection
- added test case for malicious keys
- fix malicious keys via an object-as-a-map with exclamation mark key
  encoding
- added `templateBy` to allow transformation of keys
  - used by the 'Safe' template
- removed unnecessary module names from JavaScript
- added some examples to docs

Any thoughts?
