### PR TITLE
Add getTemplateVars

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 * Risto Stevcev (https://github.com/Risto-Stevcev)  
 * Dario Oddenino (https://github.com/dariooddenino)  
 * Liam Goodacre (https://github.com/LiamGoodacre)
+* Benedict Aas (https://github.com/Shou)
 

--- a/src/Data/TemplateString/TemplateString.js
+++ b/src/Data/TemplateString/TemplateString.js
@@ -7,3 +7,10 @@ exports._buildExclamationKeyObject = function (tuples) {
   return valueMap;
 };
 
+var templatePattern = /\$\{([^}]+)\}/g;
+
+exports._getTemplateVars = function (str) {
+  return (str.match(templatePattern) || []).map(function (str) {
+    return str.substring(2, str.length - 1);
+  });
+};

--- a/src/Data/TemplateString/TemplateString.purs
+++ b/src/Data/TemplateString/TemplateString.purs
@@ -3,9 +3,11 @@ module Data.TemplateString
   , template
   , (<->)
   , templateS
+  , getTemplateVars
   ) where
 
 import Prelude (map, (<<<), show, (<>))
+import Data.Function.Uncurried (Fn1, runFn1)
 import Data.Tuple (Tuple)
 import Data.Show (class Show)
 import Data.TemplateString.Unsafe (templateBy)
@@ -34,5 +36,17 @@ templateS tmpl = template tmpl <<< map (map show)
 
 infix 7 templateS as <->
 
+-- | Get the template variables contained in a string.
+-- |
+-- | Example:
+-- | ```purescript
+-- | > getTemplateVars "Foo ${bar} baz ${qux}"
+-- | = ["bar", "qux"]
+-- | ```
+getTemplateVars :: String -> Array String
+getTemplateVars = runFn1 _getTemplateVars
+
 foreign import _buildExclamationKeyObject :: forall e. Array (Tuple String String) -> { | e }
+
+foreign import _getTemplateVars :: Fn1 String (Array String)
 


### PR DESCRIPTION
We add `getTemplateVars` so we can access the array of variables
contained within a template string. This is useful for finding
superfluous template variables.