### PR TITLE
fix(ffi): use `export const` & `const`

### DIFF
--- a/src/Data/TemplateString/TemplateString.js
+++ b/src/Data/TemplateString/TemplateString.js
@@ -1,5 +1,5 @@
 
-exports._buildExclamationKeyObject = function (tuples) {
+export const _buildExclamationKeyObject = function (tuples) {
   var valueMap = {};
   tuples.forEach(function (tuple) {
     valueMap['!' + tuple.value0] = tuple.value1;
@@ -7,9 +7,9 @@ exports._buildExclamationKeyObject = function (tuples) {
   return valueMap;
 };
 
-var templatePattern = /\$\{([^}]+)\}/g;
+const templatePattern = /\$\{([^}]+)\}/g;
 
-exports._getTemplateVars = function (str) {
+export const _getTemplateVars = function (str) {
   return (str.match(templatePattern) || []).map(function (str) {
     return str.substring(2, str.length - 1);
   });

--- a/src/Data/TemplateString/TemplateString.js
+++ b/src/Data/TemplateString/TemplateString.js
@@ -1,6 +1,6 @@
 
-export const _buildExclamationKeyObject = function (tuples) {
-  var valueMap = {};
+export const function _buildExclamationKeyObject(tuples) {
+  const valueMap = {};
   tuples.forEach(function (tuple) {
     valueMap['!' + tuple.value0] = tuple.value1;
   });
@@ -9,7 +9,7 @@ export const _buildExclamationKeyObject = function (tuples) {
 
 const templatePattern = /\$\{([^}]+)\}/g;
 
-export const _getTemplateVars = function (str) {
+export const function _getTemplateVars(str) {
   return (str.match(templatePattern) || []).map(function (str) {
     return str.substring(2, str.length - 1);
   });

--- a/src/Data/TemplateString/TemplateString.js
+++ b/src/Data/TemplateString/TemplateString.js
@@ -1,5 +1,5 @@
 
-export const function _buildExclamationKeyObject(tuples) {
+export function _buildExclamationKeyObject(tuples) {
   const valueMap = {};
   tuples.forEach(function (tuple) {
     valueMap['!' + tuple.value0] = tuple.value1;
@@ -9,7 +9,7 @@ export const function _buildExclamationKeyObject(tuples) {
 
 const templatePattern = /\$\{([^}]+)\}/g;
 
-export const function _getTemplateVars(str) {
+export function _getTemplateVars(str) {
   return (str.match(templatePattern) || []).map(function (str) {
     return str.substring(2, str.length - 1);
   });

--- a/src/Data/TemplateString/Unsafe/TemplateString.js
+++ b/src/Data/TemplateString/Unsafe/TemplateString.js
@@ -1,9 +1,9 @@
 
 const templatePattern = /\$\{([^}]+)\}/g;
 
-export const _templateBy = function (keyFrom, str, obj) {
+export const function _templateBy(keyFrom, str, obj) {
   return str.replace(templatePattern, function (match, ident) {
-     var key = keyFrom(ident);
+     const key = keyFrom(ident);
      return Object.hasOwnProperty.call(obj, key) ? obj[key] : match;
   });
 };

--- a/src/Data/TemplateString/Unsafe/TemplateString.js
+++ b/src/Data/TemplateString/Unsafe/TemplateString.js
@@ -1,7 +1,7 @@
 
 const templatePattern = /\$\{([^}]+)\}/g;
 
-export const function _templateBy(keyFrom, str, obj) {
+export function _templateBy(keyFrom, str, obj) {
   return str.replace(templatePattern, function (match, ident) {
      const key = keyFrom(ident);
      return Object.hasOwnProperty.call(obj, key) ? obj[key] : match;

--- a/src/Data/TemplateString/Unsafe/TemplateString.js
+++ b/src/Data/TemplateString/Unsafe/TemplateString.js
@@ -1,7 +1,7 @@
 
-var templatePattern = /\$\{([^}]+)\}/g;
+const templatePattern = /\$\{([^}]+)\}/g;
 
-exports._templateBy = function (keyFrom, str, obj) {
+export const _templateBy = function (keyFrom, str, obj) {
   return str.replace(templatePattern, function (match, ident) {
      var key = keyFrom(ident);
      return Object.hasOwnProperty.call(obj, key) ? obj[key] : match;


### PR DESCRIPTION
This should fix the warning about ES6 syntax when you execute `spago build`.